### PR TITLE
[N/A] replaces X with Bluesky

### DIFF
--- a/src/components/ui/social-menu.tsx
+++ b/src/components/ui/social-menu.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 
-import { FaLinkedin, FaXTwitter, FaYoutube } from 'react-icons/fa6';
+import { FaLinkedin, FaYoutube, FaBluesky } from 'react-icons/fa6';
 
 import { cn } from '@/lib/utils';
 
@@ -13,9 +13,9 @@ const SOCIAL_NETWORKS = [
     icon: <FaLinkedin className="h-4 w-4" />,
   },
   {
-    name: 'X',
-    url: 'https://x.com/more4nature',
-    icon: <FaXTwitter className="h-4 w-4" />,
+    name: 'Bluesky',
+    url: 'https://bsky.app/profile/more4nature.eu',
+    icon: <FaBluesky className="h-4 w-4" />,
   },
   {
     name: 'YouTube',


### PR DESCRIPTION
This pull request updates the social media icons and links in the `social-menu` component to reflect the latest platforms used.

Key changes:

* Replaced the `FaXTwitter` icon with the `FaBluesky` icon in the import statement in `src/components/ui/social-menu.tsx`.
* Updated the social network list to replace the entry for "X" with "Bluesky", including the name, URL, and icon in `src/components/ui/social-menu.tsx`.