### PR TITLE
Fix upstream service name formatting in config.yaml

### DIFF
--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -42,7 +42,7 @@ applications:
 routes:
   "https://{default}/":
     type: upstream
-    upstream: "more4nature-website:http"
+    upstream: more4nature-website:http
     
   "https://www.{default}/":
     type: redirect


### PR DESCRIPTION
Removed quotes around upstream service name in config.